### PR TITLE
[DO NOT MERGE (yet)] AN-165285 - Applying fix to XSDDateTime.deepCopyNotNull

### DIFF
--- a/hibernate/org.eclipse.emf.teneo.hibernate/src/org/eclipse/emf/teneo/hibernate/mapping/XSDDateTime.java
+++ b/hibernate/org.eclipse.emf.teneo.hibernate/src/org/eclipse/emf/teneo/hibernate/mapping/XSDDateTime.java
@@ -66,15 +66,13 @@ public class XSDDateTime extends MutableType {
 	}
 
 	/*
-	 * Copy the XMLGregorianCalendar object
+	 * Just return the original value.
 	 * 
 	 * @see org.hibernate.type.MutableType#deepCopyNotNull(java.lang.Object)
 	 */
 	@Override
 	public Object deepCopyNotNull(Object value) {
-		return dataTypeFactory
-				.newXMLGregorianCalendar(((XMLGregorianCalendar) value)
-						.toGregorianCalendar());
+		return value;
 	}
 
 	/*


### PR DESCRIPTION
Effectively cherry-picking the below commit.

https://github.com/appian/org.eclipse.emf.teneo/commit/efbac23a549191c76df16c28aa42ebbd08a76c40#diff-a0cc69fadcce542f83ec07aaa33360d9